### PR TITLE
DP-12820 Migrate semaphore users off static cc-root-1 credentials

### DIFF
--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -14,7 +14,6 @@ global_job_config:
       - make install-vault
       - . mk-include/bin/vault-setup
       - . vault-sem-get-secret semaphore-secrets-global
-      - . vault-sem-get-secret aws_credentials
       - . vault-sem-get-secret ssh_id_rsa
       - . vault-sem-get-secret netrc
       - . vault-sem-get-secret ssh_config

--- a/.semaphore/publish_to_s3.yml
+++ b/.semaphore/publish_to_s3.yml
@@ -17,7 +17,6 @@ global_job_config:
             - make install-vault
             - . mk-include/bin/vault-setup
             - . vault-sem-get-secret semaphore-secrets-global
-            - . vault-sem-get-secret aws_credentials
             - . vault-sem-get-secret dockerhub-semaphore-cred-ro
             - . vault-sem-get-secret ssh_id_rsa
             - . vault-sem-get-secret netrc

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,6 @@ global_job_config:
       - make install-vault
       - . mk-include/bin/vault-setup
       - . vault-sem-get-secret semaphore-secrets-global
-      - . vault-sem-get-secret aws_credentials
       - . vault-sem-get-secret dockerhub-semaphore-cred-ro
       - . vault-sem-get-secret ssh_id_rsa
       - . vault-sem-get-secret netrc


### PR DESCRIPTION
## Background
Currently, some semaphore projects contain unnecessary secrets which execute a script to authenticate with `cc-root-1` or `caas-dev`. This is problematic since this secret actually changes the build system to use the AWS IAM user (a static, long lived AWS credential) with broad permissions instead of the IAM role of the semaphore agent as originally intended.

This change is the first step in DevProd's goal of adopting dynamic credentials; we will begin removing static credentials in the coming quarter.

## Changes
This PR removes the `eng_aws`and/or `aws_credentials` secret so the builds will run as the IAM role of the semaphore agent `519856050701:role/onprem-s1-*` instead of the long lived user `368821881613:user/semaphoreci` or `037803949979:user/semaphoreci`.

This secret is not needed for most pipelines since the semaphore agent IAM role has permissions to pull images and upload artifacts. This secret is only needed if your pipeline requires a specific resource in the account which a PR build should catch.

## Actions
If the PR build succeeds, and you don't need a resource in the `368821881613` or `037803949979` account, please merge this change. The PR build will catch everything except the release stages - either way the rollback is straightforward, and this is ci/cd facing only.

If the PR build fails, then your pipeline requires a resource in the cc-root-1 account, and we will work with you on required permissions.

For questions, please reach out to #devprod-oncall, and for more details, please see: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3033867557/CI+System+Migration+Jenkins-+Semaphore#Secrets
