### PR TITLE
[DP-12820] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -5,19 +5,10 @@ agent:
     type: s1-prod-ubuntu20-04-amd64-1
     os_image: ''
 global_job_config:
-  secrets:
-    - name: vault_sem2_approle
   prologue:
     commands:
-      - chmod 400 ~/.ssh/id_rsa
       - checkout
-      - make install-vault
-      - . mk-include/bin/vault-setup
-      - . vault-sem-get-secret semaphore-secrets-global
-      - . vault-sem-get-secret ssh_id_rsa
-      - . vault-sem-get-secret netrc
-      - . vault-sem-get-secret ssh_config
-      - . vault-sem-get-secret gitconfig
+      - . vault-setup
       - . vault-sem-get-secret gradle_properties
       - chmod 700 ~/.netrc
       - make init-ci

--- a/.semaphore/publish_to_s3.yml
+++ b/.semaphore/publish_to_s3.yml
@@ -8,20 +8,10 @@ agent:
     machine:
         type: s1-prod-ubuntu20-04-amd64-1
 global_job_config:
-    secrets:
-        - name: vault_sem2_approle
     prologue:
         commands:
-            - chmod 400 ~/.ssh/id_rsa
             - checkout
-            - make install-vault
-            - . mk-include/bin/vault-setup
-            - . vault-sem-get-secret semaphore-secrets-global
-            - . vault-sem-get-secret dockerhub-semaphore-cred-ro
-            - . vault-sem-get-secret ssh_id_rsa
-            - . vault-sem-get-secret netrc
-            - . vault-sem-get-secret ssh_config
-            - . vault-sem-get-secret gitconfig
+            - . vault-setup
             - . vault-sem-get-secret csid-bundles
             - . vault-sem-get-secret csid_aws_credentials
             - . vault-sem-get-secret gradle_properties

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,21 +9,10 @@ auto_cancel:
 execution_time_limit:
   hours: 1
 global_job_config:
-  secrets:
-    - name: vault_sem2_approle
   prologue:
     commands:
-      - chmod 400 ~/.ssh/id_rsa
       - checkout
-      - make install-vault
-      - . mk-include/bin/vault-setup
-      - . vault-sem-get-secret semaphore-secrets-global
-      - . vault-sem-get-secret dockerhub-semaphore-cred-ro
-      - . vault-sem-get-secret ssh_id_rsa
-      - . vault-sem-get-secret netrc
-      - . vault-sem-get-secret ssh_config
-      - . vault-sem-get-secret gitconfig
-      - . vault-sem-get-secret maven-settings
+      - . vault-setup
       - . vault-sem-get-secret gradle_properties
       - . vault-sem-get-secret csid-bundles
       - chmod 700 ~/.m2/settings.xml


### PR DESCRIPTION
## Background
This is a followup to DP-12820 to clean up semaphore pipelines. This change removes some secrets that have been
deactivated as well as removes some commands that are set automatically by the semaphore agent, and replaces
two lines make install-vault and mk-include/bin/vault-setup with . vault-setup.

The same [change](https://github.com/confluentinc/cc-service-bot/pull/471/files) was made for managed semaphore pipelines, this automated PR
should match the changes made in the managed semaphore pipelines.

## Actions
This should not affect your pipelines. If the commands match what was made in the managed semaphore pipelines,
and the pr build passes, please merge this change.
